### PR TITLE
fix strict argument added

### DIFF
--- a/half_json/core.py
+++ b/half_json/core.py
@@ -20,13 +20,13 @@ class JSONFixer(object):
         try:
             json.loads(line, strict=strict)
             return FixResult(success=True, line=line, origin=True)
-        except Exception as e:
+        except Exception:
             pass
 
-        ok, new_line = self.fixwithtry(line)
+        ok, new_line = self.fixwithtry(line, strict=strict)
         return FixResult(success=ok, line=new_line, origin=False)
 
-    def fixwithtry(self, line):
+    def fixwithtry(self, line, strict=True):
         if self._max_try <= 0:
             return False, line
 
@@ -35,7 +35,7 @@ class JSONFixer(object):
 
         for i in range(self._max_try):
 
-            ok, new_line = self.patch_line(line)
+            ok, new_line = self.patch_line(line, strict=strict)
             if ok:
                 return ok, new_line
 
@@ -47,8 +47,8 @@ class JSONFixer(object):
             line = new_line
         return ok, line
 
-    def patch_line(self, line):
-        result = decode_line(line)
+    def patch_line(self, line, strict=True):
+        result = decode_line(line, strict=strict)
         if result.success:
             return True, line
 

--- a/half_json/core.py
+++ b/half_json/core.py
@@ -18,7 +18,7 @@ class JSONFixer(object):
 
     def fix(self, line, strict=True):
         try:
-            json.loads(line, strict=True)
+            json.loads(line, strict=strict)
             return FixResult(success=True, line=line, origin=True)
         except Exception as e:
             pass

--- a/half_json/core.py
+++ b/half_json/core.py
@@ -16,9 +16,9 @@ class JSONFixer(object):
         self._max_stack = max_stack
         self._js_style = js_style
 
-    def fix(self, line):
+    def fix(self, line, strict=True):
         try:
-            json.loads(line)
+            json.loads(line, strict=True)
             return FixResult(success=True, line=line, origin=True)
         except Exception as e:
             pass

--- a/half_json/json_util.py
+++ b/half_json/json_util.py
@@ -96,10 +96,10 @@ def record_parser_name(parser):
     return new_parser
 
 
-def make_decoder():
+def make_decoder(strict=True):
     json.decoder.scanstring = record_parser_name(py_scanstring)
 
-    decoder = JSONDecoder()
+    decoder = JSONDecoder(strict=strict)
     decoder.parse_object = record_parser_name(decoder.parse_object)
     decoder.parse_array = record_parser_name(decoder.parse_array)
     decoder.parse_string = record_parser_name(py_scanstring)
@@ -110,14 +110,15 @@ def make_decoder():
 
 
 decoder = make_decoder()
+decoder_unstrict = make_decoder(strict=False)
 
 
 DecodeResult = namedtuple('DecodeResult', ['success', 'exception', 'err_info'])
 
 
-def decode_line(line):
+def decode_line(line, strict=True):
     try:
-        obj, end = decoder.scan_once(line, 0)
+        obj, end = (decoder if strict else decoder_unstrict).scan_once(line, 0)
         ok = end == len(line)
         return DecodeResult(success=ok, exception=None, err_info=(obj, end))
     except StopIteration as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 
 [project]
 name = "jsonfixer"
-version = "0.2.0"
+version = "0.2.1"
 description = "jsonfixer: fix invalid json: broken-json / truncated-json."
 authors = [
     {name = "alingse", email = "alingse@foxmail.com"},
 ]
 dependencies = []
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 readme = "README.md"
 license = {text = "MIT"}
 classifiers = [

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -102,3 +102,19 @@ class TestSimpleCase(unittest.TestCase):
         ok, newline, _ = JSONFixer().fix(line)
         self.assertTrue(ok)
         self.assertEqual('[null]', newline)
+
+    def test_unstrict_ok(self):
+        line = '{"hello": "wor\nld"}'
+        ok, newline, _ = JSONFixer().fix(line)
+        self.assertFalse(ok)
+        ok, newline, _ = JSONFixer().fix(line, strict=False)
+        self.assertTrue(ok)
+        self.assertEqual(line, newline)
+
+    def test_unstrict_fix(self):
+        line = '{"hello": "wor\nld"'
+        ok, newline, _ = JSONFixer().fix(line)
+        self.assertFalse(ok)
+        ok, newline, _ = JSONFixer().fix(line, strict=False)
+        self.assertTrue(ok)
+        self.assertEqual('{"hello": "wor\nld"}', newline)


### PR DESCRIPTION
fix: strict argument added (defaults to true as in json.loads for compatibility)

Usecase: consider json below returned by chatgpt, fixer can't handle it without strict=False parameter.
```
{\n  "text": "Apart from the Business Unlimited Pro 2.0 Smartphone package, we also offer the Business Unlimited Tablet Start plan. Here are the details:\n\n# Business Unlimited Tablet Start\nPrice: $30 per month per tablet\n\nFeatures:\n- 5G Nationwide/4G LTE\n- Video streaming at 480p\n\nThis plan also offers the option to add additional devices. Please let me know if you need information on any other plans or services.",\n  "quick_replies": ["Tell me more about additional devices", "What are the terms and conditions?", "Do you offer any discounts?", "I want to know about other plans"]\n}'
```